### PR TITLE
Encode IPsec PSK in Base64

### DIFF
--- a/ps.openaccessitalia.org-main/app/Http/Controllers/Admin/AdminController.php
+++ b/ps.openaccessitalia.org-main/app/Http/Controllers/Admin/AdminController.php
@@ -84,6 +84,10 @@ class AdminController extends Controller
                         }
                     }
                 break;
+                case 'PIRACY_SHIELD_VPN_PSK':
+                    file_put_contents($path, str_replace("$key=\"".env($key)."\"","$key=\"".base64_encode($value)."\"", file_get_contents($path)));
+                    $_ENV[$key] = $value;
+                break;
                 default:
                     file_put_contents($path, str_replace("$key=\"".env($key)."\"","$key=\"$value\"", file_get_contents($path)));
                     $_ENV[$key] = $value;

--- a/ps.openaccessitalia.org-main/app/Http/Controllers/PiracyController.php
+++ b/ps.openaccessitalia.org-main/app/Http/Controllers/PiracyController.php
@@ -1916,9 +1916,9 @@ EOD;
                 \App\Http\Controllers\Admin\ActionLogController::log(0,"piracy_system","failed to make piracy shield vpn ipsec conf file in '".base_path('storage/settings/').'ipsec_conf.add'."' (".$e->getMessage().")",true);
             }
             //ipsec_secret.add
-            $psk = env('PIRACY_SHIELD_VPN_PSK');
+            $psk = base64_encode(env('PIRACY_SHIELD_VPN_PSK'));
             $content = <<<EOD
-$right : PSK "$psk"
+$right : PSK 0s$psk
 EOD;
             try{
                 file_put_contents(base_path('storage/settings/').'ipsec_secrets.add',$content);

--- a/ps.openaccessitalia.org-main/resources/views/admin/settings/edit.blade.php
+++ b/ps.openaccessitalia.org-main/resources/views/admin/settings/edit.blade.php
@@ -186,7 +186,7 @@
                                         <div class="form-group col-md-12">
                                             <label for="PIRACY_SHIELD_VPN_PSK">VPN pre-shared key</label>
                                             <div class="input-group">
-                                                <input type="password" class="form-control" id="PIRACY_SHIELD_VPN_PSK" name="PIRACY_SHIELD_VPN_PSK" value="{{env("PIRACY_SHIELD_VPN_PSK")}}" placeholder="127.0.0.1">
+                                                <input type="password" class="form-control" id="PIRACY_SHIELD_VPN_PSK" name="PIRACY_SHIELD_VPN_PSK" value="{{base64_decode(env("PIRACY_SHIELD_VPN_PSK"))}}" placeholder="127.0.0.1">
                                                 <div class="input-group-append">
                                                     <div class="input-group-text">
                                                         <i class="fas fa-key text-dark mr-1"></i>


### PR DESCRIPTION
Dato che le PSK del tunnel IPsec contengono dei caratteri speciali (nel nostro caso le doppie virgolette), i file .env e i file di configurazione possono essere compilati in modo errato.
Strongswan supporta l'encoding delle PSK in Base64, questa modifica gestisce la scrittura corretta dei file.