### PR TITLE
Fix CSRF headers in ajax requests

### DIFF
--- a/ps.openaccessitalia.org-main/resources/views/manual/lists/fqdn.blade.php
+++ b/ps.openaccessitalia.org-main/resources/views/manual/lists/fqdn.blade.php
@@ -186,7 +186,7 @@
                         value: $('#value').val(),
                         comment: $('#comment').val()
                     },
-                    headers: {'X-CSRF-TOKEN': $('meta[name="csrf_token"]').attr('content')},
+                    headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')},
                     statusCode: {
                         200: function(data) {
                             table.ajax.reload();

--- a/ps.openaccessitalia.org-main/resources/views/manual/lists/fqdn.blade.php
+++ b/ps.openaccessitalia.org-main/resources/views/manual/lists/fqdn.blade.php
@@ -217,6 +217,7 @@
             maxFiles: 1,
             maxFilesize: 10,
             acceptedFiles: "text/plain",
+            headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')},
             success: function(file){
                 var result = JSON.parse(file.xhr.response);
                 var content = '';

--- a/ps.openaccessitalia.org-main/resources/views/manual/lists/ipv4.blade.php
+++ b/ps.openaccessitalia.org-main/resources/views/manual/lists/ipv4.blade.php
@@ -186,7 +186,7 @@
                         value: $('#value').val(),
                         comment: $('#comment').val()
                     },
-                    headers: {'X-CSRF-TOKEN': $('meta[name="csrf_token"]').attr('content')},
+                    headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')},
                     statusCode: {
                         200: function(data) {
                             table.ajax.reload();

--- a/ps.openaccessitalia.org-main/resources/views/manual/lists/ipv4.blade.php
+++ b/ps.openaccessitalia.org-main/resources/views/manual/lists/ipv4.blade.php
@@ -217,6 +217,7 @@
             maxFiles: 1,
             maxFilesize: 10,
             acceptedFiles: "text/plain",
+            headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')},
             success: function(file){
                 var result = JSON.parse(file.xhr.response);
                 var content = '';

--- a/ps.openaccessitalia.org-main/resources/views/manual/lists/ipv6.blade.php
+++ b/ps.openaccessitalia.org-main/resources/views/manual/lists/ipv6.blade.php
@@ -186,7 +186,7 @@
                         value: $('#value').val(),
                         comment: $('#comment').val()
                     },
-                    headers: {'X-CSRF-TOKEN': $('meta[name="csrf_token"]').attr('content')},
+                    headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')},
                     statusCode: {
                         200: function(data) {
                             table.ajax.reload();

--- a/ps.openaccessitalia.org-main/resources/views/manual/lists/ipv6.blade.php
+++ b/ps.openaccessitalia.org-main/resources/views/manual/lists/ipv6.blade.php
@@ -217,6 +217,7 @@
             maxFiles: 1,
             maxFilesize: 10,
             acceptedFiles: "text/plain",
+            headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')},
             success: function(file){
                 var result = JSON.parse(file.xhr.response);
                 var content = '';

--- a/ps.openaccessitalia.org-main/resources/views/piracy/whitelist.blade.php
+++ b/ps.openaccessitalia.org-main/resources/views/piracy/whitelist.blade.php
@@ -137,7 +137,7 @@
                                 genre: data.genre,
                                 item: data.value
                             },
-                            headers: {'X-CSRF-TOKEN': $('meta[name="csrf_token"]').attr('content')},
+                            headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')},
                             statusCode: {
                                 200: function(data) {
                                     table.ajax.reload();
@@ -172,7 +172,7 @@
                         genre: $('#genre').val(),
                         attr: $('#attr').val(),
                     },
-                    headers: {'X-CSRF-TOKEN': $('meta[name="csrf_token"]').attr('content')},
+                    headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')},
                     statusCode: {
                         200: function(data) {
                             table.ajax.reload();


### PR DESCRIPTION
Fix per le chiamate Ajax nella funzione Whitelist, l'header corretto nella pagina si chiama "csrf-token".